### PR TITLE
Add optional vim-fugitive autocmd in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This plugin can be installed with a variety of plugin managers, e.g., [vim-plug]
 
 ```vim
 Plug 'liuchengxu/eleline.vim'
+" Optional. If you use vim-fugitive and want a callback from it to update eleline.
+" autocmd User FugitiveChanged if exists("b:eleline_branch") | unlet b:eleline_branch | endif
 ```
 
 Don't forget to `set laststatus=2` to always display statusline.


### PR DESCRIPTION
This autocmd removes eleline's cached branch name so that e.g. after a
`:Git checkout`, the branch name in eleline can be updated immediately.

This was mentioned at [1].

[1] https://github.com/liuchengxu/eleline.vim/pull/44#issuecomment-858524921

---

If I'm not mistaken, this is slightly better than `call ElelineGitBranch(1)`
since it only re-retrieves branch name next the status line updates.
