### PR TITLE
Add support for Syntastic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Currently supported plugins:
 - [vim-gutentags](https://github.com/ludovicchabant/vim-gutentags)
 - [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim)
 - [lsp-status.nvim](https://github.com/nvim-lua/lsp-status.nvim)
+- [syntastic](https://github.com/vim-syntastic/syntastic)
 
 If you're using newer vim or neovim, i.e., async API is available, eleline will probe the git branch info asynchronously instead of depending on vim-fugitive, making your vim never slower due to the statusline.
 


### PR DESCRIPTION
Syntastic [1] is a syntax checking plugin. It can be useful to introduce
additional linting info.

A new configuration `g:eleline_syntastic_raw` is introduced. When set to
`0` (default), the built-in format is used; when set to `1`, it calls
Syntastic's `SyntasticStatuslineFlag()` directly, which can be
configured by user via `g:syntastic_stl_format` [2].

[1] https://github.com/vim-syntastic/syntastic
[2] https://github.com/vim-syntastic/syntastic/blob/176f364f1b4acf894cdc248944f2d5506a37cc80/doc/syntastic.txt#L627-L643

---

Screenshots

```vim
let g:eleline_syntastic_raw = 0  " default
```
![image](https://user-images.githubusercontent.com/4507647/123260275-b9fa3700-d538-11eb-893b-9681113152ea.png)

```vim
let g:eleline_syntastic_raw = 1
let g:syntastic_stl_format = "[Syntax: line:%F (%t)]"  " default
```

![image](https://user-images.githubusercontent.com/4507647/123260612-18bfb080-d539-11eb-9a15-12ab2f652ba8.png)
