### PR TITLE
Check if lsp-status exists before calling status()

### DIFF
--- a/plugin/eleline.vim
+++ b/plugin/eleline.vim
@@ -208,7 +208,7 @@ function! ElelineFunction() abort
     let l:function = b:coc_current_function
   elseif !empty(get(b:, 'vista_nearest_method_or_function', ''))
     let l:function = b:vista_nearest_method_or_function
-  elseif has('nvim-0.5') && !s:is_tmp_file() && luaeval('#vim.lsp.buf_get_clients() > 0')
+  elseif has('nvim-0.5') && !s:is_tmp_file() && luaeval('pcall(require, "lsp-status")') && luaeval('#vim.lsp.buf_get_clients() > 0')
     let l:function = luaeval("require('lsp-status').status()")
   endif
   return !empty(l:function) ? s:fn_icon.l:function : ''


### PR DESCRIPTION
If native LSP is configured however lsp-status is not installed, it now
simply skips calling `require('lsp-status').status()` instead of throwing
an error.
